### PR TITLE
fix: git status fail when branch=true

### DIFF
--- a/plugin/mini-files-status.lua
+++ b/plugin/mini-files-status.lua
@@ -65,6 +65,8 @@ local function update_git_status()
     "git",
     "-c",
     "status.relativePaths=false",
+    "-c",
+    "status.branch=false",
     "status",
     "--short",
   }, { text = true }, function(out)


### PR DESCRIPTION
Fix an error when user set `status.branch=true`

Error:

```lua
Error executing luv callback:
...lazy/mini-files-status.nvim/plugin/mini-files-status.lua:43: attempt to compare nil with number
stack traceback:
	...lazy/mini-files-status.nvim/plugin/mini-files-status.lua:43: in function 'parse'
	...lazy/mini-files-status.nvim/plugin/mini-files-status.lua:76: in function 'on_exit'
	/usr/share/nvim/runtime/lua/vim/_system.lua:301: in function </usr/share/nvim/runtime/lua/vim/_system.lua:271>
```